### PR TITLE
Remove whitespace before grid region

### DIFF
--- a/query_apiv2.py
+++ b/query_apiv2.py
@@ -17,7 +17,7 @@ EMAIL = 'some_email@gmail.com'
 ORG = 'some org name'
 
 # request details
-    BA = 'CAISO_NORTH'  # identify grid region
+BA = 'CAISO_NORTH'  # identify grid region
 
 # starttime and endtime are optional, if ommited will return the latest value
 START = '2020-03-01T00:00:00-0000'  # UTC offset of 0 (PDT is -7, PST -8)


### PR DESCRIPTION
When executing `python query_apiv2.py` an IndentationError is thrown
```
  File "query_apiv2.py", line 19
    BA = 'CAISO_NORTH'  # identify grid region
    ^
IndentationError: unexpected indent
```